### PR TITLE
WIP 0.2.3 - Versioning to Stellaris 2.3

### DIFF
--- a/descriptor.mod
+++ b/descriptor.mod
@@ -4,4 +4,4 @@ tags={
 	"Economy"
 	"Gameplay"
 }
-supported_version="2.2.*"
+supported_version="2.3.*"


### PR DESCRIPTION
Mod is outright compatible with Stellaris 2.3, so no adaptation or patch required.